### PR TITLE
fixed malformed error for out of bounds access

### DIFF
--- a/src/frames.jl
+++ b/src/frames.jl
@@ -78,7 +78,7 @@ function Base.findfirst(id::I, frame::EntityFrame{S,D,I}) where {S,D,I}
 end
 function id2index(frame::EntityFrame{S,D,I}, id::I) where {S,D,I}
     entity_index = findfirst(id, frame)
-    if entity_index == nothing
+    if entity_index === nothing
         throw(BoundsError(frame, [id]))
     end
     return entity_index

--- a/src/frames.jl
+++ b/src/frames.jl
@@ -79,7 +79,7 @@ end
 function id2index(frame::EntityFrame{S,D,I}, id::I) where {S,D,I}
     entity_index = findfirst(id, frame)
     if entity_index == nothing
-        throw(BoundsError(frame, id))
+        throw(BoundsError(frame, [id]))
     end
     return entity_index
 end


### PR DESCRIPTION
Want error to look like in the first case, not like the second case.
![Screenshot from 2020-01-21 17-10-59](https://user-images.githubusercontent.com/53627988/72856971-16389780-3c71-11ea-83a0-21d103ce2e2c.png)
Things remain unchanged if indexing by integers
